### PR TITLE
changed the placement of the web session timeout function for vendor …

### DIFF
--- a/hhub/core/dod-ui-utl.lisp
+++ b/hhub/core/dod-ui-utl.lisp
@@ -819,26 +819,6 @@ Returns a list of widget outputs."
 	(if weseti (format t "~2,'0d:~2,'0d"
 			   (nth 0  weseti)(nth 1 weseti)))))
 
-(defun print-vendor-web-session-timeout ()
-  (with-vend-session-check 
-    (let ((weseti (get-vendor-web-session-timeout)))
-      (if weseti (format t "~2,'0d:~2,'0d"
-			 (nth 0  weseti)(nth 1 weseti))))))
-
-
-(defun get-web-session-timeout ()
-  (multiple-value-bind
-	  (seconds minute hour)
-	(decode-universal-time (+ (get-universal-time) (hunchentoot:session-max-time hunchentoot:*session*)))
-      ;;(logiamhere (format nil "Session max time is ~A" (hunchentoot:session-max-time hunchentoot:*session*)))
-      (list hour minute seconds)))
-
-(defun get-vendor-web-session-timeout ()
-    (multiple-value-bind
-	(seconds minute hour)
-	(decode-universal-time (+ (getloginvendorsessionstarttime) (hunchentoot:session-max-time hunchentoot:*session*)))
-	(list hour minute seconds)))
-
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defmacro with-cust-session-check (&body body)
     `(if hunchentoot:*session* ,@body 
@@ -862,6 +842,26 @@ Returns a list of widget outputs."
     `(if hunchentoot:*session* ,@body 
 					;else 
 	 (hunchentoot:redirect *HHUBCADLOGINPAGEURL*))))
+
+(defun print-vendor-web-session-timeout ()
+  (with-vend-session-check 
+    (let ((weseti (get-vendor-web-session-timeout)))
+      (if weseti (format t "~2,'0d:~2,'0d"
+			 (nth 0  weseti)(nth 1 weseti))))))
+
+
+(defun get-web-session-timeout ()
+  (multiple-value-bind
+	  (seconds minute hour)
+	(decode-universal-time (+ (get-universal-time) (hunchentoot:session-max-time hunchentoot:*session*)))
+      ;;(logiamhere (format nil "Session max time is ~A" (hunchentoot:session-max-time hunchentoot:*session*)))
+      (list hour minute seconds)))
+
+(defun get-vendor-web-session-timeout ()
+    (multiple-value-bind
+	(seconds minute hour)
+	(decode-universal-time (+ (getloginvendorsessionstarttime) (hunchentoot:session-max-time hunchentoot:*session*)))
+	(list hour minute seconds)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defmacro with-hhub-transaction (name &optional params &body body)


### PR DESCRIPTION
…to fix a startup bug
Here's a summary of your one commit from this morning (Sep 9, 2026):

7baa04c — "changed the placement of the web session timeout function for vendor to fix a startup bug" (Author: Nine Stores, 07:34 +0530)

What it is: a reordering-only change (20 insertions / 20 deletions) confined entirely to hhub/core/dod-ui-utl.lisp.

What changed: In that file, a block of three functions —

    print-vendor-web-session-timeout
    get-web-session-timeout
    get-vendor-web-session-timeout

was moved from above the eval-when defmacro definitions for with-cust/with-vend/with-opr/with-cad-session-check to below them.

Why it matters (the bug it fixes): print-vendor-web-session-timeout calls the macro with-vend-session-check. Because ASDF compiles each .lisp top-to-bottom, when that defun was compiled before the macro was defined, the (with-vend-session-check …) form was compiled as an ordinary function call. At runtime it then tripped SBCL's guard on the macro symbol → WITH-VEND-SESSION-CHECK is a macro, not a function on the vendor login path. Reordering so the macros are defined first makes it expand as a proper macro.

Net effect: no logic changed — pure relocation in one file that fixes the vendor web-session-timeout startup/login bug.

